### PR TITLE
feat(tracer): honor OTEL_PROPAGATORS; add sampler ratio config

### DIFF
--- a/src/rouge_ai/config.py
+++ b/src/rouge_ai/config.py
@@ -31,6 +31,8 @@ class RougeConfig:
     # OpenTelemetry Configuration
     # SECURITY: Changed to HTTPS
     otlp_endpoint: str = "https://localhost:4318/v1/traces"
+    # Head-sampling ratio (0.0-1.0). None => honor OTEL_TRACES_SAMPLER/default.
+    traces_sampler_ratio: float | None = None
 
     # Environment
     environment: str = "development"

--- a/src/rouge_ai/constants.py
+++ b/src/rouge_ai/constants.py
@@ -16,6 +16,7 @@ ENV_VAR_MAPPING = {
     "ROUGE_AWS_SESSION_TOKEN": "aws_session_token",
     "ROUGE_AWS_REGION": "aws_region",
     "ROUGE_OTLP_ENDPOINT": "otlp_endpoint",
+    "ROUGE_TRACES_SAMPLER_RATIO": "traces_sampler_ratio",
     "ROUGE_ENVIRONMENT": "environment",
     "ROUGE_ENABLE_SPAN_CONSOLE_EXPORT": "enable_span_console_export",
     "ROUGE_ENABLE_LOG_CONSOLE_EXPORT": "enable_log_console_export",

--- a/src/rouge_ai/tracer.py
+++ b/src/rouge_ai/tracer.py
@@ -119,6 +119,9 @@ def _load_env_config() -> dict[str, Any]:
                         item.strip() for item in value.split(",")
                         if item.strip()
                     ]
+                # Handle float values
+                elif config_field == "traces_sampler_ratio":
+                    env_config[config_field] = float(value)
                 else:
                     # SECURITY FIX: Validate value before using
                     env_config[config_field] = validate_config_value(
@@ -270,17 +273,25 @@ def init(**kwargs: Any) -> TracerProvider:
     # yet; otherwise reuse the existing provider instead of overriding the
     # global (which OpenTelemetry disallows, and which would orphan already-
     # instrumented libraries).
+    # Sampler: an explicit ratio (config or ROUGE_TRACES_SAMPLER_RATIO) wins;
+    # otherwise pass None so the SDK honors OTEL_TRACES_SAMPLER / its default.
+    sampler = None
+    if config.traces_sampler_ratio is not None:
+        from opentelemetry.sdk.trace.sampling import (ParentBased,
+                                                      TraceIdRatioBased)
+        sampler = ParentBased(TraceIdRatioBased(config.traces_sampler_ratio))
+
     current_provider = otel_trace.get_tracer_provider()
     if isinstance(current_provider, ProxyTracerProvider):
         tracer_verbose(config, "Creating tracer provider...")
-        provider = TracerProvider(resource=resource)
+        provider = TracerProvider(resource=resource, sampler=sampler)
         otel_trace.set_tracer_provider(provider)
     elif hasattr(current_provider, "add_span_processor"):
         tracer_verbose(config, "Reusing existing global tracer provider...")
         provider = current_provider
     else:
         tracer_verbose(config, "Creating tracer provider...")
-        provider = TracerProvider(resource=resource)
+        provider = TracerProvider(resource=resource, sampler=sampler)
         otel_trace.set_tracer_provider(provider)
 
     # Add span processors based on configuration
@@ -308,18 +319,18 @@ def init(**kwargs: Any) -> TracerProvider:
 
     _tracer_provider = provider
 
-    # Configure propagators to enable distributed tracing
-    # This is crucial for FastAPI to properly extract trace context from
-    # HTTP headers
-    # and create child spans instead of new root spans
-    tracer_verbose(config,
-                   "Configuring propagators for distributed tracing...")
-    propagator = CompositePropagator([
-        TraceContextTextMapPropagator(
-        ),  # Handles traceparent/tracestate headers (W3C Trace Context)
-        W3CBaggagePropagator(),  # Handles baggage header (W3C Baggage)
-    ])
-    set_global_textmap(propagator)
+    # Configure propagators for distributed tracing. OpenTelemetry's default
+    # global propagator is already W3C tracecontext+baggage and honors
+    # OTEL_PROPAGATORS, so only install ours when the user hasn't customized
+    # propagation via that env var (avoids clobbering a custom setup).
+    if not os.getenv("OTEL_PROPAGATORS"):
+        tracer_verbose(config,
+                       "Configuring propagators for distributed tracing...")
+        propagator = CompositePropagator([
+            TraceContextTextMapPropagator(),
+            W3CBaggagePropagator(),
+        ])
+        set_global_textmap(propagator)
 
     # Automatically instrument LLM providers if available
     instrument_llm(config)

--- a/test/tracer/test_tracer_init.py
+++ b/test/tracer/test_tracer_init.py
@@ -352,6 +352,62 @@ class TestTracerInitialization(unittest.TestCase):
         with patch.dict(os.environ, {"OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"}):
             self.assertIsInstance(_create_span_exporter(cfg), GRPCExporter)
 
+    def test_propagators_not_overridden_when_otel_env_set(self):
+        """B3: honor OTEL_PROPAGATORS - don't override global propagators."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch('rouge_ai.utils.config.Path.cwd',
+                       return_value=Path(temp_dir)):
+                with patch.dict(os.environ,
+                                {"OTEL_PROPAGATORS": "tracecontext"}):
+                    with patch('rouge_ai.tracer.set_global_textmap') as m:
+                        init(service_name='svc',
+                             local_mode=True,
+                             enable_span_cloud_export=False,
+                             enable_log_cloud_export=False)
+                        m.assert_not_called()
+
+    def test_propagators_installed_without_otel_env(self):
+        """B3: install W3C propagators when OTEL_PROPAGATORS is unset."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch('rouge_ai.utils.config.Path.cwd',
+                       return_value=Path(temp_dir)):
+                with patch.dict(os.environ):
+                    os.environ.pop("OTEL_PROPAGATORS", None)
+                    with patch('rouge_ai.tracer.set_global_textmap') as m:
+                        init(service_name='svc',
+                             local_mode=True,
+                             enable_span_cloud_export=False,
+                             enable_log_cloud_export=False)
+                        m.assert_called_once()
+
+    def test_sampler_ratio_config(self):
+        """B7: traces_sampler_ratio installs a ratio-based sampler."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch('rouge_ai.utils.config.Path.cwd',
+                       return_value=Path(temp_dir)):
+                provider = init(service_name='svc',
+                                local_mode=True,
+                                enable_span_cloud_export=False,
+                                enable_log_cloud_export=False,
+                                traces_sampler_ratio=0.25)
+        self.assertIn("0.25", provider.sampler.get_description())
+
+    def test_otel_traces_sampler_env_honored(self):
+        """B6/B7: OTEL_TRACES_SAMPLER is honored when no ratio is set."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch('rouge_ai.utils.config.Path.cwd',
+                       return_value=Path(temp_dir)):
+                with patch.dict(
+                        os.environ, {
+                            "OTEL_TRACES_SAMPLER": "traceidratio",
+                            "OTEL_TRACES_SAMPLER_ARG": "0.1"
+                        }):
+                    provider = init(service_name='svc',
+                                    local_mode=True,
+                                    enable_span_cloud_export=False,
+                                    enable_log_cloud_export=False)
+        self.assertIn("0.1", provider.sampler.get_description())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
B3: only install Rouge's W3C tracecontext+baggage propagators when the user has not set OTEL_PROPAGATORS. OTel's default global propagator already covers tracecontext+baggage and honors OTEL_PROPAGATORS, so this no longer clobbers a custom propagation setup.

B7: add traces_sampler_ratio config (+ ROUGE_TRACES_SAMPLER_RATIO env) which installs ParentBased(TraceIdRatioBased(ratio)). When unset, the SDK continues to honor OTEL_TRACES_SAMPLER (TracerProvider reads it via _get_from_env_or_default).

Resolves B3, B7. 142 tests pass; pre-commit (yapf/isort) clean.