### PR TITLE
feat(tracer): stream-safe @trace + drop pandas; safe attribute capture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "opentelemetry-semantic-conventions==0.55b1",
     "opentelemetry-util-http==0.55b1",
     "watchtower==3.4.0",
-    "pandas>=1.5.0",
     "PyYAML==6.0.2",
 ]
 
@@ -91,7 +90,6 @@ all = [
     "opentelemetry-semantic-conventions==0.55b1",
     "opentelemetry-util-http==0.55b1",
     "watchtower==3.4.0",
-    "pandas>=1.5.0",
     "PyYAML==6.0.2",
     "pytest==8.4.1",
     "pytest-asyncio==1.1.0",

--- a/src/rouge_ai/tracer.py
+++ b/src/rouge_ai/tracer.py
@@ -9,7 +9,6 @@ from functools import wraps
 from typing import Any, Callable, Sequence
 
 import opentelemetry
-import pandas as pd
 from opentelemetry import trace as otel_trace
 from opentelemetry.baggage.propagation import W3CBaggagePropagator
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import \
@@ -534,9 +533,43 @@ def trace(options: TraceOptions = TraceOptions()) -> Callable[..., Any]:
                                         options.flatten_attributes)
                 return ret
 
-        # Return appropriate wrapper based on function type
-        if inspect.iscoroutinefunction(function):
+        @wraps(function)
+        def _trace_gen_wrapper(*args: Any, **kwargs: Any) -> Any:
+            # The span must span the whole stream: a generator function returns
+            # immediately, so without iterating inside the span the span would
+            # end with ~0 duration and miss the streaming work.
+            # pattern: openllmetry traceloop-sdk base.py:278-279
+            with _trace(function, options, *args, **kwargs) as span:
+                collected = [] if options.trace_return_value else None
+                for item in function(*args, **kwargs):
+                    if collected is not None:
+                        collected.append(item)
+                    yield item
+                if collected is not None and span:
+                    _store_dict_in_span({"return": collected}, span,
+                                        options.flatten_attributes)
+
+        @wraps(function)
+        async def _trace_async_gen_wrapper(*args: Any, **kwargs: Any) -> Any:
+            with _trace(function, options, *args, **kwargs) as span:
+                collected = [] if options.trace_return_value else None
+                async for item in function(*args, **kwargs):
+                    if collected is not None:
+                        collected.append(item)
+                    yield item
+                if collected is not None and span:
+                    _store_dict_in_span({"return": collected}, span,
+                                        options.flatten_attributes)
+
+        # Return the wrapper matching the function kind. Generators and async
+        # generators are handled explicitly so streaming spans cover the full
+        # iteration rather than just object creation.
+        if inspect.isasyncgenfunction(function):
+            return _trace_async_gen_wrapper
+        elif inspect.iscoroutinefunction(function):
             return _trace_async_wrapper
+        elif inspect.isgeneratorfunction(function):
+            return _trace_gen_wrapper
         else:
             return _trace_sync_wrapper
 
@@ -550,9 +583,28 @@ def write_attributes_to_current_span(attributes: dict[str, Any]) -> None:
         _store_dict_in_span(attributes, span, flatten=False)
 
 
-def _serialize_dict(d: dict[Any, Any]) -> dict[Any, Any]:
-    """Serializes a dictionary."""
-    return json.loads(json.dumps(d, default=str))
+def _attr_value_length_limit() -> int | None:
+    """Max attribute-value length from the standard OTel env var, if set."""
+    raw = (os.getenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT")
+           or os.getenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT"))
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            return None
+    return None
+
+
+def _coerce_attr_value(value: Any) -> Any:
+    """Coerce a value into a valid OpenTelemetry attribute value.
+
+    OTel attributes accept only bool/str/bytes/int/float (or homogeneous
+    sequences of those); anything else is dropped with a warning. Non-scalar
+    values are JSON-encoded into a single string so nothing is silently lost.
+    """
+    if isinstance(value, bool) or type(value) in (int, float, str, bytes):
+        return value
+    return json.dumps(value, default=str)
 
 
 def _params_to_dict(
@@ -583,16 +635,40 @@ def _params_to_dict(
 
 
 def _store_dict_in_span(data: dict[str, Any], span: Any, flatten: bool = True):
-    """
-    Stores a dictionary in a span (as attributes), optionally flattening it.
+    """Store a dictionary on a span as attributes.
+
+    Flattens nested dicts (optional), coerces every value to a valid OTel
+    attribute type, and truncates long string values to
+    OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT when that env var is set.
     """
     if flatten:
         data = _flatten_dict(data)
-    data = {k: v if v is not None else 'None' for k, v in data.items()}
-    span.set_attributes(_serialize_dict(data))
+    max_len = _attr_value_length_limit()
+    attributes: dict[str, Any] = {}
+    for key, value in data.items():
+        coerced: Any = "None" if value is None else _coerce_attr_value(value)
+        if (max_len is not None and isinstance(coerced, str)
+                and len(coerced) > max_len):
+            coerced = coerced[:max_len]
+        attributes[str(key)] = coerced
+    span.set_attributes(attributes)
 
 
 def _flatten_dict(data: dict[str, Any], sep: str = "_") -> dict[str, Any]:
-    """Flattens a dictionary, joining parent/child keys with `sep`."""
-    flattened = pd.json_normalize(data, sep=sep).to_dict(orient="records")
-    return flattened[0] if len(flattened) > 0 else {}
+    """Flatten a nested dict, joining parent/child keys with ``sep``.
+
+    Pure-Python replacement for pandas.json_normalize (drops the heavy pandas
+    runtime dependency).
+    """
+    flattened: dict[str, Any] = {}
+
+    def _walk(obj: dict[str, Any], parent: str) -> None:
+        for key, value in obj.items():
+            new_key = f"{parent}{sep}{key}" if parent else str(key)
+            if isinstance(value, dict) and value:
+                _walk(value, new_key)
+            else:
+                flattened[new_key] = value
+
+    _walk(data, "")
+    return flattened

--- a/test/tracer/test_tracer.py
+++ b/test/tracer/test_tracer.py
@@ -171,6 +171,96 @@ class TestTracer(unittest.TestCase):
         self.assertIn(BatchSpanProcessor, processor_types)
         self.assertNotIn(SimpleSpanProcessor, processor_types)
 
+    # --- B9: capture helpers (pandas-free, valid attribute types) ----------
+
+    def test_flatten_dict_no_pandas(self):
+        """B9: nested dicts flatten without pandas."""
+        from rouge_ai.tracer import _flatten_dict
+        self.assertEqual(_flatten_dict({
+            "a": {
+                "b": 1
+            },
+            "c": 2
+        }), {
+            "a_b": 1,
+            "c": 2
+        })
+
+    def test_coerce_attr_value(self):
+        """B9: values coerce to valid OTel attribute types."""
+        from rouge_ai.tracer import _coerce_attr_value
+        self.assertEqual(_coerce_attr_value("s"), "s")
+        self.assertEqual(_coerce_attr_value(5), 5)
+        self.assertIs(_coerce_attr_value(True), True)
+        # Non-scalars are JSON-encoded into a single string.
+        self.assertEqual(_coerce_attr_value([1, 2]), "[1, 2]")
+        self.assertEqual(_coerce_attr_value({"x": 1}), '{"x": 1}')
+
+    def test_store_dict_truncates_with_env(self):
+        """B9: long values truncate to the OTel length-limit env var."""
+        import os
+
+        from rouge_ai.tracer import _store_dict_in_span
+        span = MagicMock()
+        with patch.dict(os.environ,
+                        {"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT": "5"}):
+            _store_dict_in_span({"k": "abcdefghij"}, span, flatten=False)
+        stored = span.set_attributes.call_args[0][0]
+        self.assertEqual(stored["k"], "abcde")
+
+    # --- B8: streaming spans cover the full iteration ----------------------
+
+    def _exporter_on_provider(self):
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import \
+            InMemorySpanExporter
+
+        import rouge_ai.tracer as tracer_module
+        init(service_name="svc",
+             local_mode=True,
+             enable_span_console_export=False,
+             enable_span_cloud_export=False,
+             enable_log_cloud_export=False)
+        exporter = InMemorySpanExporter()
+        tracer_module._tracer_provider.add_span_processor(
+            SimpleSpanProcessor(exporter))
+        return exporter
+
+    def test_sync_generator_span_covers_full_iteration(self):
+        """B8: a traced generator yields all items and records one span."""
+        from rouge_ai.tracer import TraceOptions, trace
+        exporter = self._exporter_on_provider()
+
+        @trace(TraceOptions(trace_return_value=True))
+        def gen():
+            yield 1
+            yield 2
+
+        self.assertEqual(list(gen()), [1, 2])
+        spans = exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0].attributes.get("return"), "[1, 2]")
+
+    def test_async_generator_span_covers_full_iteration(self):
+        """B8: a traced async generator yields all items and records a span."""
+        import asyncio
+
+        from rouge_ai.tracer import TraceOptions, trace
+        exporter = self._exporter_on_provider()
+
+        @trace(TraceOptions(trace_return_value=True))
+        async def agen():
+            yield "a"
+            yield "b"
+
+        async def consume():
+            return [x async for x in agen()]
+
+        self.assertEqual(asyncio.run(consume()), ["a", "b"])
+        spans = exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0].attributes.get("return"), '["a", "b"]')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
B8: @trace now wraps generators and async generators so the span covers the full iteration (a generator previously ended the span before yielding any item). Sync / async / generator / async-generator are dispatched explicitly.

B9/A4: replace pandas.json_normalize with a pure-Python recursive flattener (drops the heavy pandas runtime dependency), coerce every captured value to a valid OpenTelemetry attribute type (non-scalars JSON-encoded), and truncate long strings to OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT when set. Content capture stays opt-in per decorator.

Remove pandas from pyproject dependencies.

Resolves B8, B9, A4. 147 tests pass; pre-commit clean.